### PR TITLE
[Qemu] Use cpuid to determine SEV guest features

### DIFF
--- a/app/toolkit/qemu.py
+++ b/app/toolkit/qemu.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import qmp
+from cpuid.features import secure_encryption_info
 
 from models.vm import Vm, VmState
 from toolkit.network import find_available_port
@@ -94,6 +95,10 @@ def qemu_create_vm(vm: Vm, working_dir: Path, ovmf_path: Path):
     if not (godh.is_file() and launch_blob.is_file()):
         raise FileNotFoundError("Missing guest owner certificates, cannot start the VM.")
 
+    # TODO: this should be called only once, and we should have a generic abstraction
+    #       to support SEV + TDX. This will do for now.
+    sev_info = secure_encryption_info()
+
     p = subprocess.Popen(
         [
             "qemu-system-x86_64",
@@ -116,7 +121,9 @@ def qemu_create_vm(vm: Vm, working_dir: Path, ovmf_path: Path):
             "-device",
             "virtio-net-pci,netdev=net0",
             "-object",
-            f"sev-guest,id=sev0,policy={vm.sev_policy},cbitpos=51,reduced-phys-bits=5,dh-cert-file=godh-b64.txt,session-file=launch_blob-b64.txt",
+            f"sev-guest,id=sev0,policy={vm.sev_policy},cbitpos={sev_info.cbitpos},"
+            f"reduced-phys-bits={sev_info.reduced_phys_bits},"
+            "dh-cert-file=godh-b64.txt,session-file=launch_blob-b64.txt",
             "-machine",
             "confidential-guest-support=sev0",
             "-qmp",

--- a/app/toolkit/qemu.py
+++ b/app/toolkit/qemu.py
@@ -98,6 +98,8 @@ def qemu_create_vm(vm: Vm, working_dir: Path, ovmf_path: Path):
     # TODO: this should be called only once, and we should have a generic abstraction
     #       to support SEV + TDX. This will do for now.
     sev_info = secure_encryption_info()
+    if sev_info is None:
+        raise ValueError("Not running on an AMD SEV platform?")
 
     p = subprocess.Popen(
         [

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiofile==3.7.4
 aiosqlite==0.17.0
 fastapi==0.78.0
 pycrypto==2.6.1
+python-cpuid==0.1.0
 python-multipart==0.0.5
 pyyaml==6.0
 qmp==0.0.1


### PR DESCRIPTION
Replaced the hardcoded values for cbitpos and reduced-phys-bits
by values returned from cpuid. We currently call cpuid once
for each VM created.