### PR TITLE
Fix: Rebooting inside the VM shuts it down instead

### DIFF
--- a/app/toolkit/qemu.py
+++ b/app/toolkit/qemu.py
@@ -130,6 +130,7 @@ def qemu_create_vm(vm: Vm, working_dir: Path, ovmf_path: Path):
             "confidential-guest-support=sev0",
             "-qmp",
             f"tcp:localhost:{qmp_port},server=on,wait=off",
+            "--no-reboot",  # Rebooting from inside the VM shuts down the machine
             "-S",
         ],
         cwd=working_dir,


### PR DESCRIPTION
Problem: rebooting an SEV-enabled VM from the inside leads
back to Grub. The VM is then effectively stuck, as it is
out of the SEV boot process and no one will provide the disk
password on the command-line.

Solution: Turn reboots into shutdowns using the `no-reboot`
option of Qemu.